### PR TITLE
3 products

### DIFF
--- a/lib/CatShop/Controller/Product.pm
+++ b/lib/CatShop/Controller/Product.pm
@@ -1,0 +1,19 @@
+use utf8;
+
+package CatShop::Controller::Product;
+
+use parent 'Catalyst::Controller';
+use Moose;
+
+sub base : PathPart('product') ChainedParent CaptureArgs(0) {
+}
+
+sub index : GET PathPart('') Chained(base) Args(1) {
+    my ( $self, $c, $sku ) = @_;
+
+    #XXX: finalize the format of $sku, probably SKU-normalized-name
+    my $product = $c->model( 'DB::Product' )->load_sku( $sku );
+    $c->detach('/error/not_found') if !$product;
+}
+
+__PACKAGE__->meta->make_immutable;

--- a/lib/CatShop/Controller/Products.pm
+++ b/lib/CatShop/Controller/Products.pm
@@ -8,13 +8,11 @@ use Moose;
 sub base : PathPart('products') ChainedParent CaptureArgs(0) {
 }
 
-sub load : GET PathPart('') Chained(base) Args() {
+sub index : GET PathPart('') Chained(base) Args() {
     my ( $self, $c, @path ) = @_;
 
-    #XXX check that $path[-1] is not a product (XXX create products :p)
-
-    my $category = $c->model('DB::Category')->load_path( @path );
-    #XXX check category is defined
+    my $category = $c->model( 'DB::Category' )->load_path( @path );
+    $c->detach('/error/not_found') if !$category;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/CatShop/Schema/Result/Category.pm
+++ b/lib/CatShop/Schema/Result/Category.pm
@@ -76,10 +76,16 @@ __PACKAGE__->belongs_to(
     on_update     => "NO ACTION",
   },
 );
+__PACKAGE__->has_many(
+  "product_categories",
+  "CatShop::Schema::Result::ProductCategory",
+  { "foreign.category_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
 
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-13 23:48:00
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uT8zMqKnsalR9QBDvH6xbA
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-14 23:19:49
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zsm334bTLEXpLNzUFppUWQ
 
 __PACKAGE__->load_components('MaterializedPath');
 sub materialized_path_columns {

--- a/lib/CatShop/Schema/Result/MetaType.pm
+++ b/lib/CatShop/Schema/Result/MetaType.pm
@@ -1,0 +1,61 @@
+use utf8;
+package CatShop::Schema::Result::MetaType;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'CatShop::Schema::Base';
+__PACKAGE__->load_components(
+  "TimeStamp",
+  "InflateColumn::Authen::Passphrase",
+  "DynamicDefault",
+);
+__PACKAGE__->table("meta_types");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "meta_types_id_seq",
+  },
+  "name",
+  { data_type => "varchar", is_nullable => 0, size => 256 },
+  "created_at",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+    set_on_create => 1,
+  },
+  "updated_at",
+  {
+    data_type     => "timestamp with time zone",
+    is_nullable   => 1,
+    set_on_update => 1,
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->add_unique_constraint("meta_types_name", ["name"]);
+__PACKAGE__->has_many(
+  "product_metas",
+  "CatShop::Schema::Result::ProductMeta",
+  { "foreign.meta_type_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-14 23:19:49
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:r4yInotvpI+N70Lv0TObaA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/CatShop/Schema/Result/Product.pm
+++ b/lib/CatShop/Schema/Result/Product.pm
@@ -1,0 +1,71 @@
+use utf8;
+package CatShop::Schema::Result::Product;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'CatShop::Schema::Base';
+__PACKAGE__->load_components(
+  "TimeStamp",
+  "InflateColumn::Authen::Passphrase",
+  "DynamicDefault",
+);
+__PACKAGE__->table("products");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "products_id_seq",
+  },
+  "sku",
+  { data_type => "varchar", is_nullable => 0, size => 256 },
+  "name",
+  { data_type => "varchar", is_nullable => 0, size => 256 },
+  "normalized_name",
+  { data_type => "varchar", is_nullable => 0, size => 256 },
+  "created_at",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+    set_on_create => 1,
+  },
+  "updated_at",
+  {
+    data_type     => "timestamp with time zone",
+    is_nullable   => 1,
+    set_on_update => 1,
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->add_unique_constraint("products_sku", ["sku"]);
+__PACKAGE__->has_many(
+  "product_categories",
+  "CatShop::Schema::Result::ProductCategory",
+  { "foreign.product_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
+  "product_metas",
+  "CatShop::Schema::Result::ProductMeta",
+  { "foreign.product_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-14 23:32:05
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:cMOANPlUOa6I+eMKecltAw
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/CatShop/Schema/Result/ProductCategory.pm
+++ b/lib/CatShop/Schema/Result/ProductCategory.pm
@@ -1,0 +1,82 @@
+use utf8;
+package CatShop::Schema::Result::ProductCategory;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'CatShop::Schema::Base';
+__PACKAGE__->load_components(
+  "TimeStamp",
+  "InflateColumn::Authen::Passphrase",
+  "DynamicDefault",
+);
+__PACKAGE__->table("product_category");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "product_category_id_seq",
+  },
+  "product_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "category_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "created_at",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+    set_on_create => 1,
+  },
+  "updated_at",
+  {
+    data_type     => "timestamp with time zone",
+    is_nullable   => 1,
+    set_on_update => 1,
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->add_unique_constraint(
+  "product_category_product_id_category_id",
+  ["product_id", "category_id"],
+);
+__PACKAGE__->belongs_to(
+  "category",
+  "CatShop::Schema::Result::Category",
+  { id => "category_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+__PACKAGE__->belongs_to(
+  "product",
+  "CatShop::Schema::Result::Product",
+  { id => "product_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-14 23:19:49
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XiVcvndlpGFomhNItStqJQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/CatShop/Schema/Result/ProductMeta.pm
+++ b/lib/CatShop/Schema/Result/ProductMeta.pm
@@ -1,0 +1,80 @@
+use utf8;
+package CatShop::Schema::Result::ProductMeta;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'CatShop::Schema::Base';
+__PACKAGE__->load_components(
+  "TimeStamp",
+  "InflateColumn::Authen::Passphrase",
+  "DynamicDefault",
+);
+__PACKAGE__->table("product_meta");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "product_meta_id_seq",
+  },
+  "product_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "meta_type_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "value",
+  { data_type => "text", is_nullable => 1 },
+  "created_at",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+    set_on_create => 1,
+  },
+  "updated_at",
+  {
+    data_type     => "timestamp with time zone",
+    is_nullable   => 1,
+    set_on_update => 1,
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "meta_type",
+  "CatShop::Schema::Result::MetaType",
+  { id => "meta_type_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+__PACKAGE__->belongs_to(
+  "product",
+  "CatShop::Schema::Result::Product",
+  { id => "product_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-14 23:19:49
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:EHBJpl0Aze5/+5eMPwA0gA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/CatShop/Schema/ResultSet/Product.pm
+++ b/lib/CatShop/Schema/ResultSet/Product.pm
@@ -1,0 +1,19 @@
+use utf8;
+
+package CatShop::Schema::ResultSet::Product;
+use strict;
+use warnings;
+
+use parent 'DBIx::Class::ResultSet';
+
+sub load_sku {
+    my ( $self, $sku ) = @_;
+
+    return $self->search(
+        {
+            'sku' => $sku,
+        }
+    )->first;
+}
+
+1;

--- a/sqitch/deploy/meta_types/create.sql
+++ b/sqitch/deploy/meta_types/create.sql
@@ -1,0 +1,16 @@
+-- Deploy meta_types/create
+
+BEGIN;
+
+    CREATE TABLE meta_types (
+        id              serial PRIMARY KEY,
+
+        name            varchar(256) NOT NULL,
+
+        created_at      timestamptz NOT NULL default CURRENT_TIMESTAMP,
+        updated_at      timestamptz
+    );
+
+    CREATE UNIQUE INDEX meta_types_name ON meta_types (name);
+
+COMMIT;

--- a/sqitch/deploy/product_category/create.sql
+++ b/sqitch/deploy/product_category/create.sql
@@ -1,0 +1,17 @@
+-- Deploy product_category/create
+
+BEGIN;
+
+    CREATE TABLE product_category (
+        id              serial PRIMARY KEY,
+
+        product_id      integer REFERENCES products(id),
+        category_id     integer REFERENCES categories(id),
+
+        created_at      timestamptz NOT NULL default CURRENT_TIMESTAMP,
+        updated_at      timestamptz
+    );
+
+    CREATE UNIQUE INDEX product_category_product_id_category_id ON product_category (product_id, category_id);
+
+COMMIT;

--- a/sqitch/deploy/product_meta/create.sql
+++ b/sqitch/deploy/product_meta/create.sql
@@ -1,0 +1,16 @@
+-- Deploy product_meta/create
+
+BEGIN;
+
+    CREATE TABLE product_meta (
+        id              serial PRIMARY KEY,
+
+        product_id      integer REFERENCES products(id),
+        meta_type_id    integer REFERENCES meta_types(id),
+        value           text,
+
+        created_at      timestamptz NOT NULL default CURRENT_TIMESTAMP,
+        updated_at      timestamptz
+    );
+
+COMMIT;

--- a/sqitch/deploy/products/create.sql
+++ b/sqitch/deploy/products/create.sql
@@ -1,0 +1,18 @@
+-- Deploy products/create
+
+BEGIN;
+
+    CREATE TABLE products (
+        id              serial PRIMARY KEY,
+
+        sku             varchar(256) NOT NULL,
+        name            varchar(256) NOT NULL,
+        normalized_name varchar(256) NOT NULL,
+
+        created_at      timestamptz NOT NULL default CURRENT_TIMESTAMP,
+        updated_at      timestamptz
+    );
+
+    CREATE UNIQUE INDEX products_sku ON products (sku);
+
+COMMIT;

--- a/sqitch/revert/meta_types/create.sql
+++ b/sqitch/revert/meta_types/create.sql
@@ -1,0 +1,7 @@
+-- Revert meta_types/create
+
+BEGIN;
+
+    DROP TABLE meta_types;
+
+COMMIT;

--- a/sqitch/revert/product_category/create.sql
+++ b/sqitch/revert/product_category/create.sql
@@ -1,0 +1,7 @@
+-- Revert product_category/create
+
+BEGIN;
+
+    DROP TABLE product_category;
+
+COMMIT;

--- a/sqitch/revert/product_meta/create.sql
+++ b/sqitch/revert/product_meta/create.sql
@@ -1,0 +1,7 @@
+-- Revert product_meta/create
+
+BEGIN;
+
+    DROP TABLE product_meta;
+
+COMMIT;

--- a/sqitch/revert/products/create.sql
+++ b/sqitch/revert/products/create.sql
@@ -1,0 +1,7 @@
+-- Revert products/create
+
+BEGIN;
+
+    DROP TABLE products;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -2,3 +2,7 @@
 %project=catshop
 
 categories/create 2015-01-12T21:27:56Z Mark Ellis <m@rkellis.com># add categories table
+products/create 2015-01-14T21:59:51Z Mark Ellis <m@rkellis.com># create products table
+meta_types/create 2015-01-14T22:54:14Z Mark Ellis <m@rkellis.com># create product_meta table
+product_meta/create 2015-01-14T22:54:39Z Mark Ellis <m@rkellis.com># create meta_types table
+product_category/create 2015-01-14T23:14:01Z Mark Ellis <m@rkellis.com># create product_category table

--- a/sqitch/verify/meta_types/create.sql
+++ b/sqitch/verify/meta_types/create.sql
@@ -1,0 +1,7 @@
+-- Verify meta_types/create
+
+BEGIN;
+
+    SELECT * FROM meta_types WHERE 1=1;
+
+ROLLBACK;

--- a/sqitch/verify/product_category/create.sql
+++ b/sqitch/verify/product_category/create.sql
@@ -1,0 +1,7 @@
+-- Verify product_category/create
+
+BEGIN;
+
+    SELECT * FROM product_category WHERE 1=1;
+
+ROLLBACK;

--- a/sqitch/verify/product_meta/create.sql
+++ b/sqitch/verify/product_meta/create.sql
@@ -1,0 +1,7 @@
+-- Verify product_meta/create
+
+BEGIN;
+
+    SELECT * FROM product_meta WHERE 1=1;
+
+ROLLBACK;

--- a/sqitch/verify/products/create.sql
+++ b/sqitch/verify/products/create.sql
@@ -1,0 +1,7 @@
+-- Verify products/create
+
+BEGIN;
+
+    SELECT * FROM products WHERE 1=1;
+
+ROLLBACK;


### PR DESCRIPTION
closes #3 

mostly tables, and low quality stub actions.

not tested too well since there are no products, or categories to test at the moment!

I'm not 100% happy with the URL structure, as it would be better if it could be something like

`catshop.io/products(?)/mobile-phones/android/chinese/123SKU-coolpad-8297w`
vs
`catshop.io/products/mobile-phones/android/chinese/`  and `catshop.io/product/123SKU-coolpad-8297w`

as the first option is a clear hieracy, and helps give the user a sense of navigation, although I'm not sure how many users use the url bar directly, nevermind use it to get a sense of location. but then again, every little helps...

but it's a tricky one, as it doesn't fit easily into the Chained dispatch type, so it will require a bit of a hack, although not much of one. It's just a question of is it worth it?
